### PR TITLE
Pin typescript to version 5.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"patch-package": "^8.0.0",
 				"postinstall-postinstall": "^2.1.0",
 				"roblox-ts": "^3.0.0",
-				"typescript": "^5.9.2"
+				"typescript": "5.5.3"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -2303,18 +2303,6 @@
 				"rbxtsc": "out/CLI/cli.js"
 			}
 		},
-		"node_modules/roblox-ts/node_modules/typescript": {
-			"version": "5.5.3",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"dev": true,
@@ -2548,9 +2536,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+			"integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"patch-package": "^8.0.0",
 		"postinstall-postinstall": "^2.1.0",
 		"roblox-ts": "^3.0.0",
-		"typescript": "^5.9.2"
+		"typescript": "5.5.3"
 	},
 	"dependencies": {
 		"@rbxts/catppuccin": "^1.0.2",


### PR DESCRIPTION
Set TypeScript version to exactly 5.5.3 as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-47663c3b-9ada-4641-89d1-c86f5ee8784c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47663c3b-9ada-4641-89d1-c86f5ee8784c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

